### PR TITLE
Changes to Support user specified TempDirectory to avoid 8.3 short name issue for executeScript API

### DIFF
--- a/src/main/java/com/profesorfalken/jpowershell/PowerShell.java
+++ b/src/main/java/com/profesorfalken/jpowershell/PowerShell.java
@@ -62,6 +62,8 @@ public class PowerShell implements AutoCloseable {
     private boolean scriptMode = false;
     public static final String END_SCRIPT_STRING = "--END-JPOWERSHELL-SCRIPT--";
 
+    private String tempDirectory;
+
     // Private constructor. Instance using openSession method
     private PowerShell() {
     }
@@ -89,6 +91,7 @@ public class PowerShell implements AutoCloseable {
                             : PowerShellConfig.getConfig().getProperty("waitPause"));
             this.maxWait = Long.valueOf((config != null && config.get("maxWait") != null) ? config.get("maxWait")
                     : PowerShellConfig.getConfig().getProperty("maxWait"));
+            this.tempDirectory = (config != null && config.get("tempDirectory") != null) ? ((String)config.get("tempDirectory")) : null;
         } catch (NumberFormatException nfe) {
             logger.log(Level.SEVERE,
                     "Could not read configuration. Using default values.", nfe);
@@ -350,9 +353,12 @@ public class PowerShell implements AutoCloseable {
 
         BufferedWriter tmpWriter = null;
         File tmpFile = null;
+        File dir = null;
+        if(null != tempDirectory)
+            dir = new File(tempDirectory);
 
         try {
-            tmpFile = File.createTempFile("psscript_" + new Date().getTime(), ".ps1");
+            tmpFile = File.createTempFile("psscript_" + new Date().getTime(), ".ps1",dir);
             if (!tmpFile.exists()) {
                 return null;
             }

--- a/src/test/java/com/profesorfalken/jpowershell/PowerShellTest.java
+++ b/src/test/java/com/profesorfalken/jpowershell/PowerShellTest.java
@@ -121,12 +121,14 @@ public class PowerShellTest {
     public void testLongCommand() {
         System.out.println("testLongCommand");
         if (OSDetector.isWindows()) {
+            Map<String, String> config = new HashMap<>();
+            config.put("maxWait","30000");
             PowerShell powerShell = PowerShell.openSession();
-            PowerShellResponse response = powerShell
+            PowerShellResponse response = powerShell.configuration(config)
                     .executeCommand("Get-WMIObject -List | Where{$_.name -match \"^Win32_\"} | Sort Name");
             System.out.println("Long list:" + response.getCommandOutput());
 
-            Assert.assertFalse(powerShell.isLastCommandInError());
+            Assert.assertFalse(powerShell.configuration(config).isLastCommandInError());
             Assert.assertTrue(response.getCommandOutput().length() > 1000);
 
             powerShell.close();


### PR DESCRIPTION
Changes to Support user specified TempDirectory to avoid 8.3 short name issue for executeScript API. 
End user can specify a directory instead of relying on java.io.tmpdir directory.