### PR TITLE
Made PowerShellResponseHandler public as it is exposed in public API

### DIFF
--- a/src/main/java/com/profesorfalken/jpowershell/PowerShellResponseHandler.java
+++ b/src/main/java/com/profesorfalken/jpowershell/PowerShellResponseHandler.java
@@ -22,6 +22,6 @@ package com.profesorfalken.jpowershell;
  * @author Javier Garcia Alonso
  */
 @FunctionalInterface
-interface PowerShellResponseHandler {
+public interface PowerShellResponseHandler {
     void handle(PowerShellResponse response);
 }


### PR DESCRIPTION
The interface `PowerShellResponseHandler` is package-private.
However, it is exposed through `executeCommandAndChain` in the public API, as discussed in #52 
I therefore made the interface public itself.